### PR TITLE
add jest github actions reporter

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,4 +10,6 @@ module.exports = {
   testMatch: ["<rootDir>/src/**/*.spec.+(ts|tsx|js)"],
   moduleFileExtensions: ["ts", "tsx", "js"],
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: "<rootDir>/src/" }),
+  reporters: ["default", "jest-github-actions-reporter"],
+  testLocationInResults: true,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@actions/core": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.5.tgz",
+      "integrity": "sha512-mwpoNjHSWWh0IiALdDEQi3tru124JKn0yVNziIBzTME8QRv7thwoghVuT1jBRjFvdtoHsqD58IRHy1nf86paRg==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -4336,6 +4342,15 @@
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
       "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
       "dev": true
+    },
+    "jest-github-actions-reporter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jest-github-actions-reporter/-/jest-github-actions-reporter-1.0.2.tgz",
+      "integrity": "sha512-iA8PfVL0cZYLJgPKc6K54nF8Y5PMo0vtONpi03H9I4dMPQtrrWaqXUX21dZRssIo7eGuEmhBcDrnwezRgkn+Rw==",
+      "dev": true,
+      "requires": {
+        "@actions/core": "^1.2.0"
+      }
     },
     "jest-haste-map": {
       "version": "26.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint": "^7.8.1",
     "eslint-config-prettier": "^6.11.0",
     "jest": "^26.1.0",
+    "jest-github-actions-reporter": "^1.0.2",
     "prettier": "^2.0.5",
     "ts-jest": "^26.3.0",
     "tsc-watch": "^4.2.9",


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Updates Jest config with the [jest-github-actions-reporter](https://github.com/cschleiden/jest-github-actions-reporter).

Provides better UX for a failing test by creating annotations in the "Files changed" tab.