### PR TITLE
use standard imports over path aliases

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,3 @@
-const { pathsToModuleNameMapper } = require("ts-jest/utils");
-const { compilerOptions } = require("./tsconfig");
-
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
@@ -9,7 +6,6 @@ module.exports = {
   },
   testMatch: ["<rootDir>/src/**/*.spec.+(ts|tsx|js)"],
   moduleFileExtensions: ["ts", "tsx", "js"],
-  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: "<rootDir>/src/" }),
   reporters: ["default", "jest-github-actions-reporter"],
   testLocationInResults: true,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from "~types";
-export * from "~services";
+export * from "./types";
+export * from "./services";

--- a/src/services/crop.spec.ts
+++ b/src/services/crop.spec.ts
@@ -1,5 +1,5 @@
 import { CropService } from "./crop";
-import CropData, { cropWithoutMaster, cropWithoutMasterOrAssetSize } from "~__fixtures__/crop-data";
+import CropData, { cropWithoutMaster, cropWithoutMasterOrAssetSize } from "../__fixtures__/crop-data";
 
 test("extraction of highest quality assest", () => {
   const cropService = new CropService(CropData);

--- a/src/services/crop.ts
+++ b/src/services/crop.ts
@@ -1,8 +1,9 @@
-import { PathReporter } from "io-ts/PathReporter";
-import Service from "~services/service";
-import { Asset, Crop } from "~types";
 import { either, isRight } from "fp-ts/Either";
-import Logger from "~utils/logger";
+import { PathReporter } from "io-ts/PathReporter";
+import Service from "./service";
+import { Asset } from "../types/asset";
+import { Crop } from "../types/crop";
+import { Logger } from "../utils";
 
 class CropService extends Service<Crop> {
   isValid: boolean;

--- a/src/services/iframe-post-message.spec.ts
+++ b/src/services/iframe-post-message.spec.ts
@@ -1,5 +1,5 @@
 import { IframePostMessageService } from "./iframe-post-message";
-import iframePostMessageData from "~__fixtures__/iframe-post-message-data";
+import iframePostMessageData from "../__fixtures__/iframe-post-message-data";
 
 test("validation of bad data", () => {
   const input = new MessageEvent("*", {

--- a/src/services/iframe-post-message.ts
+++ b/src/services/iframe-post-message.ts
@@ -1,9 +1,9 @@
-import { IframePostMessage } from "~types";
-import { either, isRight } from "fp-ts/Either";
-import Service from "~services/service";
-import { CropService } from "~services/crop";
 import { PathReporter } from "io-ts/PathReporter";
-import Logger from "~utils/logger";
+import { either, isRight } from "fp-ts/Either";
+import { IframePostMessage } from "../types";
+import Service from "./service";
+import { CropService } from "./crop";
+import { Logger } from "../utils";
 
 class IframePostMessageService extends Service<IframePostMessage> {
   isValid: boolean;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,1 +1,2 @@
 export * from "./iframe-post-message";
+export * from "./crop";

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -1,4 +1,4 @@
-import Logger from "~utils/logger";
+import { Logger } from "../utils";
 
 abstract class Service<T> {
   abstract isValid: boolean;

--- a/src/types/argo/action.ts
+++ b/src/types/argo/action.ts
@@ -1,5 +1,5 @@
 import * as t from "io-ts";
-import URLFromString from "~types/io-ts/URLFromString";
+import URLFromString from "../io-ts/URLFromString";
 import { ArgoMethod } from "./method";
 
 const ArgoAction = t.type({

--- a/src/types/argo/data-entity.ts
+++ b/src/types/argo/data-entity.ts
@@ -1,20 +1,15 @@
 import * as t from "io-ts";
-import URLFromString from "~types/io-ts/URLFromString";
 import { Mixed, Type, TypeC } from "io-ts";
+import URLFromString from "../io-ts/URLFromString";
 
 const DataEntity: <C extends Mixed>(codec: C) => TypeC<{ data: C; uri: Type<URL, string, unknown> }> = <
   C extends t.Mixed
 >(
   codec: C
 ) =>
-  t.type(
-    {
-      uri: URLFromString,
-      data: codec,
-    },
-    "DataEntity"
-  );
-
-// type ArgoEntity = t.TypeOf<typeof ArgoEntity>;
+  t.type({
+    uri: URLFromString,
+    data: codec,
+  });
 
 export { DataEntity };

--- a/src/types/argo/entity.ts
+++ b/src/types/argo/entity.ts
@@ -1,8 +1,8 @@
 import * as t from "io-ts";
-import URLFromString from "~types/io-ts/URLFromString";
+import { IntersectionC, KeyofC, Mixed, PartialC, ReadonlyArrayC, StringC, Type, TypeC } from "io-ts";
+import URLFromString from "../io-ts/URLFromString";
 import { ArgoAction } from "./action";
 import { ArgoLink } from "./link";
-import { IntersectionC, KeyofC, Mixed, PartialC, ReadonlyArrayC, StringC, Type, TypeC } from "io-ts";
 
 const ArgoEntity: <C extends Mixed>(
   codec: C
@@ -27,7 +27,5 @@ const ArgoEntity: <C extends Mixed>(
       links: t.readonlyArray(ArgoLink),
     }),
   ]);
-
-// type ArgoEntity = t.TypeOf<typeof ArgoEntity>;
 
 export { ArgoEntity };

--- a/src/types/argo/link.ts
+++ b/src/types/argo/link.ts
@@ -1,5 +1,5 @@
 import * as t from "io-ts";
-import URLFromString from "~types/io-ts/URLFromString";
+import URLFromString from "../io-ts/URLFromString";
 
 const ArgoLink = t.type({
   rel: t.string,

--- a/src/types/asset/asset.spec.ts
+++ b/src/types/asset/asset.spec.ts
@@ -1,5 +1,5 @@
-import { Asset } from "./asset";
 import { isRight } from "fp-ts/Either";
+import { Asset } from "./asset";
 
 test("foo", () => {
   const data = {

--- a/src/types/asset/asset.ts
+++ b/src/types/asset/asset.ts
@@ -1,5 +1,5 @@
 import * as t from "io-ts";
-import URLFromString from "~types/io-ts/URLFromString";
+import URLFromString from "../io-ts/URLFromString";
 import { Dimensions } from "./dimensions";
 import { GridMimeType } from "./grid-mime-type";
 

--- a/src/types/asset/grid-mime-type.spec.ts
+++ b/src/types/asset/grid-mime-type.spec.ts
@@ -1,5 +1,5 @@
-import { GridMimeType } from "./grid-mime-type";
 import { isLeft, isRight } from "fp-ts/Either";
+import { GridMimeType } from "./grid-mime-type";
 
 test("valid input", () => {
   ["image/jpeg", "image/png", "image/tiff"].forEach((mime) => {

--- a/src/types/collection/action-data.spec.ts
+++ b/src/types/collection/action-data.spec.ts
@@ -1,5 +1,5 @@
-import { ActionData } from "./action-data";
 import { either, isLeft, isRight } from "fp-ts/Either";
+import { ActionData } from "./action-data";
 
 test("valid input", () => {
   const data = ActionData.decode({

--- a/src/types/collection/collection.spec.ts
+++ b/src/types/collection/collection.spec.ts
@@ -1,5 +1,5 @@
-import { Collection } from "./collection";
 import { either, isLeft, isRight } from "fp-ts/Either";
+import { Collection } from "./collection";
 
 test("valid input", () => {
   const data = Collection.decode({

--- a/src/types/crop/crop.spec.ts
+++ b/src/types/crop/crop.spec.ts
@@ -1,6 +1,6 @@
-import { Crop } from "./crop";
 import { isRight } from "fp-ts/Either";
-import cropData from "~__fixtures__/crop-data";
+import { Crop } from "./crop";
+import cropData from "../../__fixtures__/crop-data";
 
 test("decoding a crop", () => {
   const parsed = Crop.decode(cropData);

--- a/src/types/crop/crop.ts
+++ b/src/types/crop/crop.ts
@@ -1,7 +1,7 @@
 import * as t from "io-ts";
 import { DateFromISOString } from "io-ts-types";
 import { Specification } from "./specification";
-import { Asset } from "~types/asset";
+import { Asset } from "../asset";
 
 const Crop = t.intersection([
   t.type({

--- a/src/types/crop/specification.spec.ts
+++ b/src/types/crop/specification.spec.ts
@@ -1,6 +1,6 @@
-import { Specification } from "./specification";
 import { isRight } from "fp-ts/Either";
-import cropData from "~__fixtures__/crop-data";
+import { Specification } from "./specification";
+import cropData from "../../__fixtures__/crop-data";
 
 test("decoding a crop specification", () => {
   const parsed = Specification.decode(cropData.specification);

--- a/src/types/crop/specification.ts
+++ b/src/types/crop/specification.ts
@@ -1,5 +1,5 @@
 import * as t from "io-ts";
-import URLFromString from "~types/io-ts/URLFromString";
+import URLFromString from "../io-ts/URLFromString";
 import { Bounds } from "./bounds";
 import { CropType } from "./crop-type";
 

--- a/src/types/iframe-post-message.ts
+++ b/src/types/iframe-post-message.ts
@@ -1,7 +1,7 @@
 import * as t from "io-ts";
-import { DataEntity } from "~/types/argo";
-import { Crop } from "~/types/crop";
-import { GridImage } from "~/types/image";
+import { DataEntity } from "./argo";
+import { Crop } from "./crop";
+import { GridImage } from "./image";
 
 const IframePostMessage = t.type({
   crop: DataEntity(Crop),

--- a/src/types/image/image.spec.ts
+++ b/src/types/image/image.spec.ts
@@ -1,6 +1,6 @@
-import { GridImage } from "./image";
-import imageData from "~__fixtures__/image-data";
 import { isRight } from "fp-ts/Either";
+import { GridImage } from "./image";
+import imageData from "../../__fixtures__/image-data";
 
 test("foo", () => {
   const parsed = GridImage.decode(imageData);

--- a/src/types/image/image.ts
+++ b/src/types/image/image.ts
@@ -1,20 +1,21 @@
 import * as t from "io-ts";
 import { DateFromISOString } from "io-ts-types";
+
 import { Identifier } from "./identifiers";
 import { UploadInfo } from "./upload-info";
-import { Asset } from "~types/asset";
 import { FileMetadata, ImageMetadata } from "./metadata";
-import { Crop } from "~types/crop";
-import { SyndicationRights, SyndicationStatus } from "~types/syndication";
-import { InvalidReason } from "~types/image/invalid-reason";
+import { InvalidReason } from "./invalid-reason";
 import { Cost } from "./cost";
 import { Persisted } from "./persisted";
-import { Lease } from "~types/lease";
-import { Collection } from "~types/collection";
-import { Usage } from "~types/usage";
 import { UserMetadata } from "./metadata";
-import { ArgoEntity, DataEntity } from "~/types/argo";
-import { EmptyUsage } from "~types/usage/empty-usage";
+import { Lease } from "../lease";
+
+import { ArgoEntity, DataEntity } from "../argo";
+import { Asset } from "../asset";
+import { Crop } from "../crop";
+import { Collection } from "../collection";
+import { SyndicationRights, SyndicationStatus } from "../syndication";
+import { EmptyUsage, Usage } from "../usage";
 
 // TODO be better!
 const UsageRights = t.unknown;

--- a/src/types/image/metadata/user-metadata.ts
+++ b/src/types/image/metadata/user-metadata.ts
@@ -1,7 +1,6 @@
 import * as t from "io-ts";
-import { ImageMetadata } from "./image-metadata";
-import { Photoshoot } from "./photoshoot";
-import { ArgoEntity } from "~types";
+import { ImageMetadata, Photoshoot } from "./";
+import { ArgoEntity } from "../../argo";
 
 const UserMetadata = t.partial({
   archived: t.boolean,

--- a/src/types/io-ts/URLFromString.spec.ts
+++ b/src/types/io-ts/URLFromString.spec.ts
@@ -1,5 +1,5 @@
-import URLFromString from "./URLFromString";
 import { either, isLeft, isRight } from "fp-ts/Either";
+import URLFromString from "./URLFromString";
 
 test("valid input", () => {
   const value = URLFromString.decode("https://a.domain.com/path/to/resource");

--- a/src/types/lease/lease.spec.ts
+++ b/src/types/lease/lease.spec.ts
@@ -1,5 +1,5 @@
-import { Lease } from "./lease";
 import { isRight } from "fp-ts/Either";
+import { Lease } from "./lease";
 
 test("blah", () => {
   const parsed = Lease.decode({});

--- a/src/types/syndication/syndication-rights.ts
+++ b/src/types/syndication/syndication-rights.ts
@@ -1,7 +1,7 @@
 import * as t from "io-ts";
 import { DateFromISOString } from "io-ts-types";
-import { Supplier } from "./supplier";
 import { Right } from "./right";
+import { Supplier } from "./supplier";
 
 const SyndicationRights = t.intersection([
   t.type({

--- a/src/types/usage/metadata/digital-metadata.ts
+++ b/src/types/usage/metadata/digital-metadata.ts
@@ -1,5 +1,5 @@
 import * as t from "io-ts";
-import URLFromString from "~types/io-ts/URLFromString";
+import URLFromString from "../../io-ts/URLFromString";
 
 const DigitalUsageMetadata = t.intersection([
   t.type({

--- a/src/types/usage/reference.ts
+++ b/src/types/usage/reference.ts
@@ -1,7 +1,7 @@
 import * as t from "io-ts";
 
 import { ReferenceType } from "./reference-type";
-import URLFromString from "~types/io-ts/URLFromString";
+import URLFromString from "../io-ts/URLFromString";
 
 const UsageReference = t.intersection([
   t.type({

--- a/src/types/usage/usage.ts
+++ b/src/types/usage/usage.ts
@@ -1,8 +1,8 @@
 import * as t from "io-ts";
 import { DateFromISOString } from "io-ts-types";
 import { UsageReference } from "./reference";
-import { UsageType } from "./usage-type";
 import { UsageStatus } from "./usage-status";
+import { UsageType } from "./usage-type";
 
 import {
   PrintUsageMetadata,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./logger";

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,4 +2,4 @@ interface Logger {
   log: (message?: unknown, ...optionalParams: unknown[]) => void;
 }
 
-export default Logger;
+export { Logger };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,11 +4,7 @@
       "module": "commonjs",
       "declaration": true,
       "outDir": "./lib",
-      "strict": true,
-      "baseUrl": "./src",
-      "paths": {
-        "~*": ["./*"]
-      }
+      "strict": true
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The TypeScript compiler doesn't re-write the paths, meaning consumers of this library won't understand imports by default.

See https://github.com/Microsoft/TypeScript/issues/25677.