### PR TITLE
a generic reporter

### DIFF
--- a/src/services/crop.spec.ts
+++ b/src/services/crop.spec.ts
@@ -4,6 +4,7 @@ import {
   legacyFormat__missingMaster,
   legacyFormat__missingMasterAndAssetSize,
 } from "./__fixtures__/crop";
+import { Reporter } from "../utils";
 
 test("extraction of highest quality asset", () => {
   const cropService = new CropService(standardCrop);
@@ -28,7 +29,7 @@ test("extraction of highest quality asset", () => {
 });
 
 test("extraction of highest quality asset when no master", () => {
-  const cropService = CropService.withConsoleLogger(legacyFormat__missingMaster);
+  const cropService = new CropService(legacyFormat__missingMaster, Reporter.default);
 
   expect(cropService.isValid).toBe(true);
 
@@ -49,7 +50,7 @@ test("extraction of highest quality asset when no master", () => {
 });
 
 test("extraction of highest quality asset when no master or sizes", () => {
-  const cropService = CropService.withConsoleLogger(legacyFormat__missingMasterAndAssetSize);
+  const cropService = new CropService(legacyFormat__missingMasterAndAssetSize, Reporter.default);
 
   expect(cropService.isValid).toBe(true);
 

--- a/src/services/crop.ts
+++ b/src/services/crop.ts
@@ -1,17 +1,16 @@
 import { either, isRight } from "fp-ts/Either";
-import { PathReporter } from "io-ts/PathReporter";
 import Service from "./service";
 import { Asset } from "../types/asset";
 import { Crop } from "../types/crop";
-import { Logger } from "../utils";
+import { Reporter } from "../utils";
 
 class CropService extends Service<Crop> {
   isValid: boolean;
   protected data?: Crop;
-  protected logger?: Logger;
+  protected reporter?: Reporter;
 
-  constructor(payload: unknown, logger: Logger | undefined = undefined) {
-    super(logger);
+  constructor(payload: unknown, reporter: Reporter | undefined = undefined) {
+    super(reporter);
 
     if (Crop.is(payload)) {
       this.isValid = true;
@@ -24,13 +23,9 @@ class CropService extends Service<Crop> {
       if (this.isValid) {
         either.map(parsed, (data: Crop) => (this.data = data));
       } else {
-        this.logger?.log(PathReporter.report(parsed));
+        this.reporter?.log(parsed);
       }
     }
-  }
-
-  static withConsoleLogger(payload: unknown): CropService {
-    return new CropService(payload, console);
   }
 
   get highestQualityAsset(): Asset | null {

--- a/src/services/iframe-post-message.spec.ts
+++ b/src/services/iframe-post-message.spec.ts
@@ -1,6 +1,7 @@
 import { IframePostMessageService } from "./iframe-post-message";
 import iframePostMessageData from "./__fixtures__/iframe-post-message";
 import iframePostMessageDataWithCollection from "./__fixtures__/iframe-post-message-with-collection";
+import { Reporter } from "../utils";
 
 test("validation of bad data", () => {
   const input = new MessageEvent("*", {
@@ -30,7 +31,7 @@ test("validation of close data", () => {
 });
 
 test("can extract image id and url to master crop from real postMessage data", () => {
-  const iframeService = IframePostMessageService.withConsoleLogger(iframePostMessageData);
+  const iframeService = new IframePostMessageService(iframePostMessageData, Reporter.default);
   expect(iframeService.isValid).toBe(true);
   expect(iframeService.imageId).toEqual("a820ad09876754cae2b1d44da01d0d9f8a83749d");
 
@@ -40,7 +41,7 @@ test("can extract image id and url to master crop from real postMessage data", (
 });
 
 test("can parse a post message response for an image with collections", () => {
-  const iframeService = IframePostMessageService.withConsoleLogger(iframePostMessageDataWithCollection);
+  const iframeService = new IframePostMessageService(iframePostMessageDataWithCollection, Reporter.default);
   expect(iframeService.isValid).toBe(true);
   expect(iframeService.highestQualityImageURL).toEqual(
     new URL(

--- a/src/services/iframe-post-message.ts
+++ b/src/services/iframe-post-message.ts
@@ -1,32 +1,27 @@
-import { PathReporter } from "io-ts/PathReporter";
 import { either, isRight } from "fp-ts/Either";
 import { IframePostMessage } from "../types";
 import Service from "./service";
 import { CropService } from "./crop";
-import { Logger } from "../utils";
+import { Reporter } from "../utils";
 
 class IframePostMessageService extends Service<IframePostMessage> {
   isValid: boolean;
   protected data?: IframePostMessage;
-  protected logger?: Logger;
+  protected reporter?: Reporter;
   private readonly cropService?: CropService;
 
-  constructor(payload: MessageEvent, logger: Logger | undefined = undefined) {
-    super(logger);
+  constructor(payload: MessageEvent, reporter: Reporter | undefined = undefined) {
+    super(reporter);
     const parsed = IframePostMessage.decode(payload.data);
 
     this.isValid = isRight(parsed);
 
     if (this.isValid) {
       either.map(parsed, (data: IframePostMessage) => (this.data = data));
-      this.cropService = new CropService(this.data?.crop.data, logger);
+      this.cropService = new CropService(this.data?.crop.data, reporter);
     } else {
-      this.logger?.log(PathReporter.report(parsed));
+      this.reporter?.log(parsed);
     }
-  }
-
-  static withConsoleLogger(payload: MessageEvent): IframePostMessageService {
-    return new IframePostMessageService(payload, console);
   }
 
   get imageId(): string | null {

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -1,12 +1,12 @@
-import { Logger } from "../utils";
+import { Reporter } from "../utils";
 
 abstract class Service<T> {
   abstract isValid: boolean;
   protected data?: T;
-  protected logger?: Logger;
+  protected reporter?: Reporter;
 
-  protected constructor(logger?: Logger) {
-    this.logger = logger;
+  protected constructor(reporter?: Reporter) {
+    this.reporter = reporter;
   }
 }
 

--- a/src/types/image/image.spec.ts
+++ b/src/types/image/image.spec.ts
@@ -1,7 +1,6 @@
 import { isLeft, isRight } from "fp-ts/Either";
 import { GridImage } from "./image";
 import { image } from "./__fixtures__/image";
-import { Reporter } from "../../utils";
 
 test("decoding standard image response", () => {
   const parsed = GridImage.decode(image);
@@ -14,8 +13,5 @@ test("decoding invalid input", () => {
   };
 
   const parsed = GridImage.decode(data);
-
-  Reporter.default.log(parsed);
-
   expect(isLeft(parsed)).toBe(true);
 });

--- a/src/types/image/image.spec.ts
+++ b/src/types/image/image.spec.ts
@@ -1,8 +1,21 @@
-import { isRight } from "fp-ts/Either";
+import { isLeft, isRight } from "fp-ts/Either";
 import { GridImage } from "./image";
 import { image } from "./__fixtures__/image";
+import { Reporter } from "../../utils";
 
 test("decoding standard image response", () => {
   const parsed = GridImage.decode(image);
   expect(isRight(parsed)).toBe(true);
+});
+
+test("decoding invalid input", () => {
+  const data = {
+    foo: "bar",
+  };
+
+  const parsed = GridImage.decode(data);
+
+  Reporter.default.log(parsed);
+
+  expect(isLeft(parsed)).toBe(true);
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./logger";
+export * from "./reporter";

--- a/src/utils/reporter.ts
+++ b/src/utils/reporter.ts
@@ -1,0 +1,22 @@
+import { Left, Right } from "fp-ts/Either";
+import { Errors } from "io-ts";
+import { PathReporter } from "io-ts/PathReporter";
+import { Logger } from "./logger";
+
+class Reporter {
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  log(parsed: Left<Errors> | Right<unknown>): void {
+    this.logger.log(PathReporter.report(parsed));
+  }
+
+  static get default(): Reporter {
+    return new Reporter(console);
+  }
+}
+
+export { Reporter };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Makes the reporter generic for use outside of `Service`s (check commit history for example).