### PR TITLE
test decoding into a Property

### DIFF
--- a/src/types/syndication/property.spec.ts
+++ b/src/types/syndication/property.spec.ts
@@ -1,0 +1,27 @@
+import { isLeft, isRight } from "fp-ts/Either";
+import { Property } from "./property";
+
+test("decoding payloads that use null instead of undefined should be a left", () => {
+  const parsed = Property.decode({
+    propertyCode: "foo",
+    expiresOn: null,
+    value: null,
+  });
+  expect(isLeft(parsed)).toBe(true);
+});
+
+test("decoding payloads that use undefined for missing values should be a right", () => {
+  const parsed = Property.decode({
+    propertyCode: "foo",
+    expiresOn: undefined,
+    value: undefined,
+  });
+  expect(isRight(parsed)).toBe(true);
+});
+
+test("decoding payloads that omit missing values should be a right", () => {
+  const parsed = Property.decode({
+    propertyCode: "foo",
+  });
+  expect(isRight(parsed)).toBe(true);
+});


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds tests for Property and its optional fields. `null` is not a valid value for an optional field, `undefined` or omitting the field is valid.

Related to https://github.com/guardian/grid/pull/3033.